### PR TITLE
Add: getStart() and getEnd() with full DateTime object

### DIFF
--- a/Classes/Domain/Model/Event.php
+++ b/Classes/Domain/Model/Event.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace ScoutNet\ShScoutnetWebservice\Domain\Model;
 
 use DateTime;
@@ -33,409 +34,449 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
  * Event
  *
  */
-class Event extends AbstractEntity {
-	/**
-	 * @var string
-	 * @TYPO3\\CMS\\Extbase\\Annotation\\Validate NotEmpty
-	 * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=2, maximum=80)
-	 */
-	protected $title;
-
-	/**
-	 * @var string
-	 * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=2, maximum=255)
-	 */
-	protected $organizer;
-
-	/**
-	 * @var string
-	 * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=2, maximum=255)
-	 */
-	protected $targetGroup;
-
-	/**
-	 * @var \DateTime
-	 * @TYPO3\\CMS\\Extbase\\Annotation\\Validate NotEmpty
-	 */
-	protected $startDate;
-	/**
-	 * @var string
-	 */
-	protected $startTime;
-
-	/**
-	 * @var \DateTime
-	 */
-	protected $endDate;
-	/**
-	 * @var string
-	 */
-	protected $endTime;
-
-	/**
-	 * @var string
-	 * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=3, maximum=255)
-	 */
-	protected $zip;
-
-	/**
-	 * @var string
-	 * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=2, maximum=255)
-	 */
-	protected $location;
-
-	/**
-	 * @var string
-	 * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=3, maximum=255)
-	 */
-	protected $urlText;
-
-	/**
-	 * @var string
-	 * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=3, maximum=255)
-	 */
-	protected $url;
-
-	/**
-	 * @var string
-	 */
-	protected $description;
-
-	/**
-	 * @var \ScoutNet\ShScoutnetWebservice\Domain\Model\Section[]
-	 */
-	protected $sections = [];
-
-	/**
-	 * @var \ScoutNet\ShScoutnetWebservice\Domain\Model\Category[]
-	 */
-	protected $categories = [];
-
-	/**
-	 * Kalender
-	 *
-	 * @var \ScoutNet\ShScoutnetWebservice\Domain\Model\Structure
+class Event extends AbstractEntity
+{
+    /**
+     * @var string
      * @TYPO3\\CMS\\Extbase\\Annotation\\Validate NotEmpty
-	 */
-	protected $structure = NULL;
+     * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=2, maximum=80)
+     */
+    protected $title;
 
-	/**
-	 * changedBy
-	 *
-	 * @var \ScoutNet\ShScoutnetWebservice\Domain\Model\User
-	 */
-	protected $changedBy = NULL;
+    /**
+     * @var string
+     * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=2, maximum=255)
+     */
+    protected $organizer;
 
-	/**
-	 * changedBy
-	 *
-	 * @var \ScoutNet\ShScoutnetWebservice\Domain\Model\User
-	 */
-	protected $createdBy = NULL;
+    /**
+     * @var string
+     * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=2, maximum=255)
+     */
+    protected $targetGroup;
 
-	/**
-	 * createdAt
-	 *
-	 * @var \DateTime
-	 */
-	protected $createdAt;
+    /**
+     * @var \DateTime
+     * @TYPO3\\CMS\\Extbase\\Annotation\\Validate NotEmpty
+     */
+    protected $startDate;
+    /**
+     * @var string
+     */
+    protected $startTime;
 
-	/**
-	 * changedAt
-	 *
-	 * @var \DateTime
-	 */
-	protected $changedAt;
+    /**
+     * @var \DateTime
+     */
+    protected $endDate;
+    /**
+     * @var string
+     */
+    protected $endTime;
 
-	/**
-	 * @return string
-	 */
-	public function getTitle(): string {
-		return $this->title??'';
-	}
+    /**
+     * @var string
+     * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=3, maximum=255)
+     */
+    protected $zip;
+
+    /**
+     * @var string
+     * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=2, maximum=255)
+     */
+    protected $location;
+
+    /**
+     * @var string
+     * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=3, maximum=255)
+     */
+    protected $urlText;
+
+    /**
+     * @var string
+     * @TYPO3\\CMS\\Extbase\\Annotation\\Validate StringLength(minimum=3, maximum=255)
+     */
+    protected $url;
+
+    /**
+     * @var string
+     */
+    protected $description;
+
+    /**
+     * @var \ScoutNet\ShScoutnetWebservice\Domain\Model\Section[]
+     */
+    protected $sections = [];
+
+    /**
+     * @var \ScoutNet\ShScoutnetWebservice\Domain\Model\Category[]
+     */
+    protected $categories = [];
+
+    /**
+     * Kalender
+     *
+     * @var \ScoutNet\ShScoutnetWebservice\Domain\Model\Structure
+     * @TYPO3\\CMS\\Extbase\\Annotation\\Validate NotEmpty
+     */
+    protected $structure = NULL;
+
+    /**
+     * changedBy
+     *
+     * @var \ScoutNet\ShScoutnetWebservice\Domain\Model\User
+     */
+    protected $changedBy = NULL;
+
+    /**
+     * changedBy
+     *
+     * @var \ScoutNet\ShScoutnetWebservice\Domain\Model\User
+     */
+    protected $createdBy = NULL;
+
+    /**
+     * createdAt
+     *
+     * @var \DateTime
+     */
+    protected $createdAt;
+
+    /**
+     * changedAt
+     *
+     * @var \DateTime
+     */
+    protected $changedAt;
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title ?? '';
+    }
 
     /**
      * @param string $title
      */
-	public function setTitle(string $title) {
-		$this->title = $title;
-	}
+    public function setTitle(string $title)
+    {
+        $this->title = $title;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getOrganizer(): string {
-		return $this->organizer??'';
-	}
+    /**
+     * @return string
+     */
+    public function getOrganizer(): string
+    {
+        return $this->organizer ?? '';
+    }
 
     /**
      * @param string $organizer
      */
-	public function setOrganizer(string $organizer) {
-		$this->organizer = $organizer;
-	}
+    public function setOrganizer(string $organizer)
+    {
+        $this->organizer = $organizer;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getTargetGroup(): string {
-		return $this->targetGroup??'';
-	}
+    /**
+     * @return string
+     */
+    public function getTargetGroup(): string
+    {
+        return $this->targetGroup ?? '';
+    }
 
     /**
      * @param string $targetGroup
      */
-	public function setTargetGroup(string $targetGroup) {
-		$this->targetGroup = $targetGroup;
-	}
+    public function setTargetGroup(string $targetGroup)
+    {
+        $this->targetGroup = $targetGroup;
+    }
 
-	/**
-	 * @return \DateTime
-	 */
-	public function getStartDate(): ?DateTime {
+    /**
+     * @return \DateTime
+     */
+    public function getStartDate(): ?DateTime
+    {
         if ($this->startTime) {
-            $startDate = DateTime::createFromFormat('Y-m-d H:i:s',$this->startDate->format('Y-m-d').' '.$this->startTime.(substr_count($this->startTime,':') == 1?':00':''));
+            $startDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->startDate->format('Y-m-d') . ' ' . $this->startTime . (substr_count($this->startTime, ':') == 1 ? ':00' : ''));
         } else {
-            $startDate = DateTime::createFromFormat('Y-m-d H:i:s',$this->startDate->format('Y-m-d').' 00:00:00');
+            $startDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->startDate->format('Y-m-d') . ' 00:00:00');
         }
 
         return $startDate;
-	}
+    }
 
-	/**
-	 * @param \DateTime $startDate
-	 */
-	public function setStartDate(DateTime $startDate) {
-		$this->startDate = $startDate;
-	}
+    /**
+     * @param \DateTime $startDate
+     */
+    public function setStartDate(DateTime $startDate)
+    {
+        $this->startDate = $startDate;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getStartTime(): ?string {
-		return $this->startTime;
-	}
+    /**
+     * @return string
+     */
+    public function getStartTime(): ?string
+    {
+        return $this->startTime;
+    }
 
     /**
      * @param string|null $startTime
      */
-	public function setStartTime(?string $startTime) {
-		$this->startTime = $startTime;
-	}
+    public function setStartTime(?string $startTime)
+    {
+        $this->startTime = $startTime;
+    }
 
-	/**
-	 * @return \DateTime
-	 */
-	public function getEndDate(): ?DateTime {
-    	if ($this->endDate && $this->endTime) {
-            $endDate = DateTime::createFromFormat('Y-m-d H:i:s',$this->endDate->format('Y-m-d').' '.$this->endTime.(substr_count($this->endTime,':') == 1?':00':''));
+    /**
+     * @return \DateTime
+     */
+    public function getEndDate(): ?DateTime
+    {
+        if ($this->endDate && $this->endTime) {
+            $endDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->endDate->format('Y-m-d') . ' ' . $this->endTime . (substr_count($this->endTime, ':') == 1 ? ':00' : ''));
         } elseif ($this->endTime) {
-            $endDate = DateTime::createFromFormat('Y-m-d H:i:s',$this->startDate->format('Y-m-d').' '.$this->endTime.(substr_count($this->endTime,':') == 1?':00':''));
+            $endDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->startDate->format('Y-m-d') . ' ' . $this->endTime . (substr_count($this->endTime, ':') == 1 ? ':00' : ''));
         } elseif ($this->endDate) {
-            $endDate = DateTime::createFromFormat('Y-m-d H:i:s',$this->endDate->format('Y-m-d').' 00:00:00');
+            $endDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->endDate->format('Y-m-d') . ' 00:00:00');
         } else {
             $endDate = $this->getStartDate();
         }
         return $endDate;
-	}
+    }
 
     /**
      * @param \DateTime|null $endDate
      */
-	public function setEndDate(?DateTime $endDate) {
-		$this->endDate = $endDate;
-	}
+    public function setEndDate(?DateTime $endDate)
+    {
+        $this->endDate = $endDate;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getEndTime(): ?string {
-		return $this->endTime;
-	}
+    /**
+     * @return string
+     */
+    public function getEndTime(): ?string
+    {
+        return $this->endTime;
+    }
 
     /**
      * @param string|null $endTime
      */
-	public function setEndTime(?string $endTime) {
-		$this->endTime = $endTime;
-	}
+    public function setEndTime(?string $endTime)
+    {
+        $this->endTime = $endTime;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getZip(): string {
-		return $this->zip??'';
-	}
+    /**
+     * @return string
+     */
+    public function getZip(): string
+    {
+        return $this->zip ?? '';
+    }
 
     /**
      * @param string $zip
      */
-	public function setZip(string $zip) {
-		$this->zip = $zip;
-	}
+    public function setZip(string $zip)
+    {
+        $this->zip = $zip;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getLocation(): string {
-		return $this->location??'';
-	}
+    /**
+     * @return string
+     */
+    public function getLocation(): string
+    {
+        return $this->location ?? '';
+    }
 
     /**
      * @param string $location
      */
-	public function setLocation(string $location) {
-		$this->location = $location;
-	}
+    public function setLocation(string $location)
+    {
+        $this->location = $location;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getUrlText(): string {
-		return $this->urlText??'';
-	}
+    /**
+     * @return string
+     */
+    public function getUrlText(): string
+    {
+        return $this->urlText ?? '';
+    }
 
     /**
      * @param string $urlText
      */
-	public function setUrlText(string $urlText) {
-		$this->urlText = $urlText;
-	}
+    public function setUrlText(string $urlText)
+    {
+        $this->urlText = $urlText;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getUrl(): string {
-		return $this->url??'';
-	}
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->url ?? '';
+    }
 
     /**
      * @param string $url
      */
-	public function setUrl(string $url) {
-		$this->url = $url;
-	}
+    public function setUrl(string $url)
+    {
+        $this->url = $url;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getDescription(): string {
-		return $this->description??'';
-	}
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description ?? '';
+    }
 
     /**
      * @param string $description
      */
-	public function setDescription(string $description) {
-		$this->description = $description;
-	}
+    public function setDescription(string $description)
+    {
+        $this->description = $description;
+    }
 
-	/**
-	 * @return \ScoutNet\ShScoutnetWebservice\Domain\Model\Structure
-	 */
-	public function getStructure(): ?Structure {
-		return $this->structure;
-	}
+    /**
+     * @return \ScoutNet\ShScoutnetWebservice\Domain\Model\Structure
+     */
+    public function getStructure(): ?Structure
+    {
+        return $this->structure;
+    }
 
-	/**
-	 * @param \ScoutNet\ShScoutnetWebservice\Domain\Model\Structure $structure
-	 */
-	public function setStructure(Structure $structure) {
-		$this->structure = $structure;
-	}
+    /**
+     * @param \ScoutNet\ShScoutnetWebservice\Domain\Model\Structure $structure
+     */
+    public function setStructure(Structure $structure)
+    {
+        $this->structure = $structure;
+    }
 
-	/**
-	 * @return \ScoutNet\ShScoutnetWebservice\Domain\Model\User
-	 */
-	public function getChangedBy(): ?User {
-		return $this->changedBy;
-	}
+    /**
+     * @return \ScoutNet\ShScoutnetWebservice\Domain\Model\User
+     */
+    public function getChangedBy(): ?User
+    {
+        return $this->changedBy;
+    }
 
     /**
      * @param \ScoutNet\ShScoutnetWebservice\Domain\Model\User $changedBy
      */
-	public function setChangedBy(User $changedBy) {
-		$this->changedBy = $changedBy;
-	}
+    public function setChangedBy(User $changedBy)
+    {
+        $this->changedBy = $changedBy;
+    }
 
-	/**
-	 * @return \ScoutNet\ShScoutnetWebservice\Domain\Model\User
-	 */
-	public function getCreatedBy(): ?User {
-		return $this->createdBy;
-	}
+    /**
+     * @return \ScoutNet\ShScoutnetWebservice\Domain\Model\User
+     */
+    public function getCreatedBy(): ?User
+    {
+        return $this->createdBy;
+    }
 
     /**
      * @param \ScoutNet\ShScoutnetWebservice\Domain\Model\User $createdBy
      */
-	public function setCreatedBy(User $createdBy) {
-		$this->createdBy = $createdBy;
-	}
+    public function setCreatedBy(User $createdBy)
+    {
+        $this->createdBy = $createdBy;
+    }
 
-	/**
-	 * @return \DateTime
-	 */
-	public function getCreatedAt(): ?DateTime {
-		return $this->createdAt;
-	}
+    /**
+     * @return \DateTime
+     */
+    public function getCreatedAt(): ?DateTime
+    {
+        return $this->createdAt;
+    }
 
     /**
      * @param \DateTime $createdAt
      */
-	public function setCreatedAt(DateTime $createdAt) {
-		$this->createdAt = $createdAt;
-	}
+    public function setCreatedAt(DateTime $createdAt)
+    {
+        $this->createdAt = $createdAt;
+    }
 
-	/**
-	 * @return \DateTime
-	 */
-	public function getChangedAt(): DateTime {
-		return $this->changedAt;
-	}
+    /**
+     * @return \DateTime
+     */
+    public function getChangedAt(): DateTime
+    {
+        return $this->changedAt;
+    }
 
     /**
      * @param \DateTime $changedAt
      */
-	public function setChangedAt(DateTime $changedAt) {
-		$this->changedAt = $changedAt;
-	}
+    public function setChangedAt(DateTime $changedAt)
+    {
+        $this->changedAt = $changedAt;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getCategories(): array {
-		return $this->categories;
-	}
+    /**
+     * @return array
+     */
+    public function getCategories(): array
+    {
+        return $this->categories;
+    }
 
     /**
      * @param array $categories
      */
-	public function setCategories(array $categories) {
-		$this->categories = $categories;
-	}
+    public function setCategories(array $categories)
+    {
+        $this->categories = $categories;
+    }
 
-	/**
-	 * @param \ScoutNet\ShScoutnetWebservice\Domain\Model\Category $category
+    /**
+     * @param \ScoutNet\ShScoutnetWebservice\Domain\Model\Category $category
      */
-	public function addCategory(Category $category) {
-		$this->categories[$category->getUid()] = $category;
-	}
+    public function addCategory(Category $category)
+    {
+        $this->categories[$category->getUid()] = $category;
+    }
 
     /**
      * @return \ScoutNet\ShScoutnetWebservice\Domain\Model\User|null
      * @deprecated
      */
 
-	public function getAuthor(): ?User {
-		if ($this->changedBy != null) return $this->changedBy;
-		return $this->createdBy;
-	}
+    public function getAuthor(): ?User
+    {
+        if ($this->changedBy != null) return $this->changedBy;
+        return $this->createdBy;
+    }
 
     /**
      * @return \ScoutNet\ShScoutnetWebservice\Domain\Model\Section[]
      * @deprecated
      */
-    public function getStufen(): array {
+    public function getStufen(): array
+    {
         return $this->getSections();
     }
 
@@ -443,7 +484,8 @@ class Event extends AbstractEntity {
      * @param \ScoutNet\ShScoutnetWebservice\Domain\Model\Section[] $sections
      * @deprecated
      */
-    public function setStufen(array $sections) {
+    public function setStufen(array $sections)
+    {
         $this->setSections($sections);
     }
 
@@ -451,149 +493,168 @@ class Event extends AbstractEntity {
      * @param \ScoutNet\ShScoutnetWebservice\Domain\Model\Section $stufe
      * @deprecated
      */
-    public function addStufe(Section $stufe) {
+    public function addStufe(Section $stufe)
+    {
         $this->addSection($stufe);
     }
 
     /**
      * @return \ScoutNet\ShScoutnetWebservice\Domain\Model\Section[]
      */
-    public function getSections(): array {
+    public function getSections(): array
+    {
         return $this->sections;
     }
 
     /**
      * @param \ScoutNet\ShScoutnetWebservice\Domain\Model\Section[] $sections
      */
-    public function setSections(array $sections) {
+    public function setSections(array $sections)
+    {
         $this->sections = $sections;
     }
 
     /**
      * @param \ScoutNet\ShScoutnetWebservice\Domain\Model\Section $section
      */
-    public function addSection(Section $section) {
+    public function addSection(Section $section)
+    {
         $this->sections[] = $section;
     }
 
-	/**
-	 * @return string
+    /**
+     * @return string
      * @deprecated
      */
-	public function getStufenImages(): string {
-	    return $this->getSectionImages();
+    public function getStufenImages(): string
+    {
+        return $this->getSectionImages();
     }
 
     /**
      * @return string
      */
-    public function getSectionImages(): string {
+    public function getSectionImages(): string
+    {
         $sections = "";
         foreach ($this->getSections() as $section) {
             $sections .= $section->getImageURL();
         }
-        return (string) $sections;
-	}
+        return (string)$sections;
+    }
 
     /**
      * @return array
      * @deprecated
      */
-	public function getStufenCategories(): array {
-	    return $this->getSectionCategories();
+    public function getStufenCategories(): array
+    {
+        return $this->getSectionCategories();
     }
 
     /**
      * @return array
      */
-    public function getSectionCategories(): array {
-		$categories = [];
-		foreach ($this->getSections() as $section) {
-			$cat = $section->getCategory();
-			$categories[$cat->getUid()] = $cat;
-		}
+    public function getSectionCategories(): array
+    {
+        $categories = [];
+        foreach ($this->getSections() as $section) {
+            $cat = $section->getCategory();
+            $categories[$cat->getUid()] = $cat;
+        }
 
-		return $categories;
-	}
+        return $categories;
+    }
 
     /**
      * @return int Start time in seconds since the Unix Epoch
      */
-	public function getStartTimestamp(): int {
+    public function getStartTimestamp(): int
+    {
         return $this->getStartDate()->format("U");
-	}
+    }
 
     /**
      * @return int End time in seconds since the Unix Epoch
      */
-	public function getEndTimestamp(): int {
+    public function getEndTimestamp(): int
+    {
         return $this->getEndDate()->format("U");
-	}
+    }
 
     /**
      * @return bool
      */
-	public function getShowEndDateOrTime(): bool {
-		return $this->getShowEndDate() || $this->getShowEndTime();
-	}
+    public function getShowEndDateOrTime(): bool
+    {
+        return $this->getShowEndDate() || $this->getShowEndTime();
+    }
 
     /**
      * @return bool
      */
-	public function getShowEndDate(): bool {
-		return !is_null($this->endDate) && $this->endDate != 0 && $this->endDate != $this->startDate;
-	}
+    public function getShowEndDate(): bool
+    {
+        return !is_null($this->endDate) && $this->endDate != 0 && $this->endDate != $this->startDate;
+    }
 
     /**
      * @return bool
      */
-	public function getShowEndTime(): bool {
-		return !is_null($this->endTime);
-	}
+    public function getShowEndTime(): bool
+    {
+        return !is_null($this->endTime);
+    }
 
     /**
      * @return bool
      */
-	public function getAllDayEvent(): bool {
-		return is_null($this->startTime);
-	}
+    public function getAllDayEvent(): bool
+    {
+        return is_null($this->startTime);
+    }
 
     /**
      * @return string
      */
-	public function getStartYear(): string {
-		return $this->startDate->format('Y');
-	}
+    public function getStartYear(): string
+    {
+        return $this->startDate->format('Y');
+    }
 
     /**
      * @return string
      */
-	public function getStartMonth(): string {
-		return $this->startDate->format('m');
-	}
+    public function getStartMonth(): string
+    {
+        return $this->startDate->format('m');
+    }
 
     /**
      * @return bool
      */
-	public function getShowDetails(): bool {
-		return trim($this->getDescription().$this->getZip().$this->getLocation().$this->getOrganizer().$this->getTargetGroup().$this->getUrl()) !== '';
-	}
+    public function getShowDetails(): bool
+    {
+        return trim($this->getDescription() . $this->getZip() . $this->getLocation() . $this->getOrganizer() . $this->getTargetGroup() . $this->getUrl()) !== '';
+    }
 
-	/**
-	 * @param int $uid
+    /**
+     * @param int $uid
      */
-	public function setUid (int $uid) {
-		$this->uid = $uid;
-	}
+    public function setUid(int $uid)
+    {
+        $this->uid = $uid;
+    }
 
     /**
      * @param Event $event
      */
-	public function copyProperties(Event $event) {
-		$copyProperties = array( 'title', 'organizer', 'targetGroup', 'startDate', 'startTime', 'endDate', 'endTime', 'zip', 'location', 'urlText', 'url', 'description', 'structure', 'categories');
+    public function copyProperties(Event $event)
+    {
+        $copyProperties = array('title', 'organizer', 'targetGroup', 'startDate', 'startTime', 'endDate', 'endTime', 'zip', 'location', 'urlText', 'url', 'description', 'structure', 'categories');
 
-		foreach ($copyProperties as $property) {
-			$this->{$property} = $event->{$property};
-		}
-	}
+        foreach ($copyProperties as $property) {
+            $this->{$property} = $event->{$property};
+        }
+    }
 }

--- a/Classes/Domain/Model/Event.php
+++ b/Classes/Domain/Model/Event.php
@@ -198,17 +198,14 @@ class Event extends AbstractEntity
     }
 
     /**
+     * Start date, without time, as \DateTime object
      * @return \DateTime
+     * @deprecated 6.0.0 Don't return full \DateTime object
+     * @see Event::getStart()
      */
     public function getStartDate(): ?DateTime
     {
-        if ($this->startTime) {
-            $startDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->startDate->format('Y-m-d') . ' ' . $this->startTime . (substr_count($this->startTime, ':') == 1 ? ':00' : ''));
-        } else {
-            $startDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->startDate->format('Y-m-d') . ' 00:00:00');
-        }
-
-        return $startDate;
+        return $this->startDate;
     }
 
     /**
@@ -236,20 +233,14 @@ class Event extends AbstractEntity
     }
 
     /**
+     * End date, without time, as \DateTime object.
      * @return \DateTime
+     * @deprecated 6.0.0 Don't return full \DateTime object
+     * @see Event::getEnd()
      */
     public function getEndDate(): ?DateTime
     {
-        if ($this->endDate && $this->endTime) {
-            $endDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->endDate->format('Y-m-d') . ' ' . $this->endTime . (substr_count($this->endTime, ':') == 1 ? ':00' : ''));
-        } elseif ($this->endTime) {
-            $endDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->startDate->format('Y-m-d') . ' ' . $this->endTime . (substr_count($this->endTime, ':') == 1 ? ':00' : ''));
-        } elseif ($this->endDate) {
-            $endDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->endDate->format('Y-m-d') . ' 00:00:00');
-        } else {
-            $endDate = $this->getStartDate();
-        }
-        return $endDate;
+        return $this->endDate;
     }
 
     /**
@@ -567,19 +558,52 @@ class Event extends AbstractEntity
     }
 
     /**
-     * @return int Start time in seconds since the Unix Epoch
+     * @return \DateTime
+     * @deprecated 6.0.0 Don't return timestamp; Confusing name
+     * @see Event::getStart()
      */
-    public function getStartTimestamp(): int
+    public function getStartTimestamp(): \DateTime
     {
-        return $this->getStartDate()->format("U");
+        return $this->getStart();
     }
 
     /**
-     * @return int End time in seconds since the Unix Epoch
+     * @return \DateTime
+     * @deprecated 6.0.0 Don't return timestamp; Confusing name
+     * @see Event::getEnd()
      */
-    public function getEndTimestamp(): int
+    public function getEndTimestamp(): \DateTime
     {
-        return $this->getEndDate()->format("U");
+        return $this->getEnd();
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getStart(): \DateTime {
+        if ($this->startTime) {
+            $startDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->startDate->format('Y-m-d') . ' ' . $this->startTime . (substr_count($this->startTime, ':') == 1 ? ':00' : ''));
+        } else {
+            $startDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->startDate->format('Y-m-d') . ' 00:00:00');
+        }
+
+        return $startDate;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getEnd(): \DateTime {
+        if ($this->endDate && $this->endTime) {
+            $endDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->endDate->format('Y-m-d') . ' ' . $this->endTime . (substr_count($this->endTime, ':') == 1 ? ':00' : ''));
+        } elseif ($this->endTime) {
+            $endDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->startDate->format('Y-m-d') . ' ' . $this->endTime . (substr_count($this->endTime, ':') == 1 ? ':00' : ''));
+        } elseif ($this->endDate) {
+            $endDate = DateTime::createFromFormat('Y-m-d H:i:s', $this->endDate->format('Y-m-d') . ' 00:00:00');
+        } else {
+            $endDate = $this->getStartTimestamp();
+        }
+        return $endDate;
     }
 
     /**
@@ -616,6 +640,8 @@ class Event extends AbstractEntity
 
     /**
      * @return string
+     * @deprecated 6.0.0
+     * @see Event::getStart() Use DateTime with format("Y") instead.
      */
     public function getStartYear(): string
     {
@@ -624,6 +650,8 @@ class Event extends AbstractEntity
 
     /**
      * @return string
+     * @deprecated 6.0.0
+     * @see Event::getStart() Use DateTime with format("m") instead.
      */
     public function getStartMonth(): string
     {

--- a/Classes/Domain/Model/Event.php
+++ b/Classes/Domain/Model/Event.php
@@ -110,7 +110,7 @@ class Event extends AbstractEntity {
 	 * @var \ScoutNet\ShScoutnetWebservice\Domain\Model\Category[]
 	 */
 	protected $categories = [];
-	
+
 	/**
 	 * Kalender
 	 *
@@ -193,7 +193,13 @@ class Event extends AbstractEntity {
 	 * @return \DateTime
 	 */
 	public function getStartDate(): ?DateTime {
-		return $this->startDate;
+        if ($this->startTime) {
+            $startDate = DateTime::createFromFormat('Y-m-d H:i:s',$this->startDate->format('Y-m-d').' '.$this->startTime.(substr_count($this->startTime,':') == 1?':00':''));
+        } else {
+            $startDate = DateTime::createFromFormat('Y-m-d H:i:s',$this->startDate->format('Y-m-d').' 00:00:00');
+        }
+
+        return $startDate;
 	}
 
 	/**
@@ -221,7 +227,16 @@ class Event extends AbstractEntity {
 	 * @return \DateTime
 	 */
 	public function getEndDate(): ?DateTime {
-		return $this->endDate;
+    	if ($this->endDate && $this->endTime) {
+            $endDate = DateTime::createFromFormat('Y-m-d H:i:s',$this->endDate->format('Y-m-d').' '.$this->endTime.(substr_count($this->endTime,':') == 1?':00':''));
+        } elseif ($this->endTime) {
+            $endDate = DateTime::createFromFormat('Y-m-d H:i:s',$this->startDate->format('Y-m-d').' '.$this->endTime.(substr_count($this->endTime,':') == 1?':00':''));
+        } elseif ($this->endDate) {
+            $endDate = DateTime::createFromFormat('Y-m-d H:i:s',$this->endDate->format('Y-m-d').' 00:00:00');
+        } else {
+            $endDate = $this->getStartDate();
+        }
+        return $endDate;
 	}
 
     /**
@@ -502,32 +517,17 @@ class Event extends AbstractEntity {
 	}
 
     /**
-     * @return \DateTime
+     * @return int Start time in seconds since the Unix Epoch
      */
-	public function getStartTimestamp(): DateTime {
-		if ($this->startTime) {
-			$startTimestamp = DateTime::createFromFormat('Y-m-d H:i:s',$this->startDate->format('Y-m-d').' '.$this->startTime.(substr_count($this->startTime,':') == 1?':00':''));
-		} else {
-			$startTimestamp = DateTime::createFromFormat('Y-m-d H:i:s',$this->startDate->format('Y-m-d').' 00:00:00');
-		}
-
-		return $startTimestamp;
+	public function getStartTimestamp(): int {
+        return $this->getStartDate()->format("U");
 	}
 
     /**
-     * @return \DateTime
+     * @return int End time in seconds since the Unix Epoch
      */
-	public function getEndTimestamp(): DateTime {
-		if ($this->endDate && $this->endTime) {
-			$endTimestamp = DateTime::createFromFormat('Y-m-d H:i:s',$this->endDate->format('Y-m-d').' '.$this->endTime.(substr_count($this->endTime,':') == 1?':00':''));
-		} elseif ($this->endTime) {
-			$endTimestamp = DateTime::createFromFormat('Y-m-d H:i:s',$this->startDate->format('Y-m-d').' '.$this->endTime.(substr_count($this->endTime,':') == 1?':00':''));
-		} elseif ($this->endDate) {
-			$endTimestamp = DateTime::createFromFormat('Y-m-d H:i:s',$this->endDate->format('Y-m-d').' 00:00:00');
-		} else {
-			$endTimestamp = $this->getStartTimestamp();
-		}
-		return $endTimestamp;
+	public function getEndTimestamp(): int {
+        return $this->getEndDate()->format("U");
 	}
 
     /**

--- a/Tests/Unit/Domain/Model/EventTest.php
+++ b/Tests/Unit/Domain/Model/EventTest.php
@@ -1,0 +1,71 @@
+<?php
+namespace ScoutNet\ShScoutnetWebservice\Tests\Unit\Domain\Model;
+
+/***************************************************************
+ *
+ *  Copyright notice
+ *
+ *  (c) 2023 André Flemming <andre@scoutnet.de>, ScoutNet
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use ScoutNet\ShScoutnetWebservice\Domain\Model\Event;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+class EventTest extends UnitTestCase {
+    private function dataproviderEventStart() {
+
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function eventStartDateReturns()
+    {
+        $startDate = \DateTime::createFromFormat("U", "703382238");
+
+        $testEntity = new Event();
+        $testEntity->setStartDate($startDate);
+        $testEntity->setStartTime($startDate->format("H:i:s"));
+
+        $this->assertEquals($startDate, $testEntity->getStart(), "test getStart()");
+        $this->assertEquals($startDate, $testEntity->getStartTimestamp(), "test getStartTimestamp()");
+        $this->assertEquals($startDate->format("H:i:s"), $testEntity->getStartTime(), "test getStartTime()");
+        $this->assertEquals($startDate->modify("midnight"), $testEntity->getStartDate(), "test getStartDate()");
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function eventEndDateReturns()
+    {
+        $endDate = \DateTime::createFromFormat("U", "1673303929");
+
+        $testEntity = new Event();
+        $testEntity->setEndDate($endDate);
+        $testEntity->setEndTime($endDate->format("H:i:s"));
+
+        $this->assertEquals($endDate, $testEntity->getEnd(), "test getEnd()");
+        $this->assertEquals($endDate, $testEntity->getEndTimestamp(), "test getEndTimestamp()");
+        $this->assertEquals($endDate->format("H:i:s"), $testEntity->getEndTime(), "test getEndTime()");
+        $this->assertEquals($endDate->modify("midnight"), $testEntity->getEndDate(), "test getEndDate()");
+    }
+}


### PR DESCRIPTION
Actual behavior:

- `getStartDate()` return a `\DateTime` object, without respecting `startTime`.
- `getStartTimestamp()` return a `DateTime` object.

Expected:
- `getStartDate()` return a full `\DateTime` object.
- `getStartTimestamp()` return a timestamp.